### PR TITLE
fix: support inquirer 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "inquirer": "7.x"
+    "inquirer": ">= 7.x"
   },
   "devDependencies": {
     "@semantic-release/git": "^9.0.0",


### PR DESCRIPTION
With npm 7 and the new way `peerDependencies` are installed, this module currently fails when using inquirer 8.

After looking through the code, it appears this module supports [inquirer 8](https://github.com/SBoudrias/Inquirer.js/releases/tag/inquirer%408.0.0).

This PR adds support for it and uses `>=` in order to prevent this problem in the future. An alternative would be to use `7.x || 8.x` instead.